### PR TITLE
Makes fungus spread in a better way [WIP]

### DIFF
--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
@@ -105,16 +105,17 @@
 		var/wall_limit = 4
 		for(var/d2 in GLOB.cardinals)
 			var/turf/T2 = get_step(T,d2)
-			var/datum/air_mixture = T2.return_air()
-			if(!air_mixture)
-				wall_limit = 0
-				break
-			var/pressure = air_mxiture.return_pressure()
-			if(pressure <= 50 || pressure >= 200)
-				wall_limit = 0
-				break
 			if(T2.density) //We are contained from this direction.
 				wall_limit -= 1
+			else //Open turf.
+				var/datum/air_mixture = T2.return_air()
+				if(!air_mixture)
+					wall_limit = 0
+					break
+				var/pressure = air_mxiture.return_pressure()
+				if(pressure <= 50 || pressure >= 200)
+					wall_limit = 0
+					break
 		if(wall_limit <= 0) //Don't spread to intersections. If we're completely enclosed and unreachable, don't spread to it.
 			continue
 

--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
@@ -105,6 +105,14 @@
 		var/wall_limit = 4
 		for(var/d2 in GLOB.cardinals)
 			var/turf/T2 = get_step(T,d2)
+			var/datum/air_mixture = T2.return_air()
+			if(!air_mixture)
+				wall_limit = 0
+				break
+			var/pressure = air_mxiture.return_pressure()
+			if(pressure <= 50 || pressure >= 200)
+				wall_limit = 0
+				break
 			if(T2.density) //We are contained from this direction.
 				wall_limit -= 1
 		if(wall_limit <= 0) //Don't spread to intersections. If we're completely enclosed and unreachable, don't spread to it.

--- a/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
+++ b/modular_skyrat/modules/wall_fungus/code/wall_fungus_component.dm
@@ -23,7 +23,7 @@
 	/// How far can we spread?
 	var/spread_distance = 3 // Tiles
 	/// How likely are we to drop a shroom upon destruction?
-	var/drop_chance = 30
+	var/drop_chance = 8 // 2 out of 25 walls will bear fruit
 
 /datum/component/wall_fungus/Initialize(override_progression_step_amount, override_spread_chance, override_spread_distance, override_drop_chance)
 	if(!iswallturf(parent))
@@ -96,14 +96,24 @@
 /datum/component/wall_fungus/proc/spread_to_nearby_wall()
 	var/turf/closed/wall/parent_wall = parent
 	var/list/walls_to_pick_from = list()
-	for(var/turf/closed/wall/iterating_wall in RANGE_TURFS(3, parent_wall))
-		if(iterating_wall.GetComponent(/datum/component/wall_fungus))
+	for(var/d in GLOB.cardinals) //Get north, east, south, west.
+		var/turf/T = get_step(parent,d)
+		if(!iswallturf(T)) //Not even a wall.
+			continue
+		if(iterating_wall.GetComponent(/datum/component/wall_fungus)) //We exist already!
+			continue
+		var/wall_limit = 4
+		for(var/d2 in GLOB.cardinals)
+			var/turf/T2 = get_step(T,d2)
+			if(T2.density) //We are contained from this direction.
+				wall_limit -= 1
+		if(wall_limit <= 0) //Don't spread to intersections. If we're completely enclosed and unreachable, don't spread to it.
 			continue
 
 		walls_to_pick_from += iterating_wall
 
 	if(!length(walls_to_pick_from))
-		return // sad times
+		return // No walls found.
 
 	var/turf/closed/wall/picked_wall = pick(walls_to_pick_from)
 


### PR DESCRIPTION
## About The Pull Request

Makes it so that fungus can spread inside enclosed turfs that can't be reached.
Reduces seed drop chance.
Wall fungus can no longer spread to turfs that has another turf adjacent to it with very high 200kpa or very low (50kpa) pressure.

## Why It's Good For The Game

Wall fungus is a terrible event. This hugboxes it so it isn't as terrible.

## Changelog

:cl: BurgerBB
balance: Wall fungus no longer spreads to turfs touching space, or turfs that are encased in other turfs. Also reduces seed drop chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
